### PR TITLE
Fix dependency on jQuery

### DIFF
--- a/xlsx.js
+++ b/xlsx.js
@@ -4061,7 +4061,7 @@ var XLSX = {};
         f3('vba');
         f3('comments');
         f3('drawings');
-        $.each(ct.sheets, function(index){
+        ct.sheets.forEach(function(sheet, index){
             o[o.length] = '<Override PartName="/xl/drawings/drawing' + (index + 1) + '.xml" ContentType="application/vnd.openxmlformats-officedocument.drawing+xml"/>';
         });
 


### PR DESCRIPTION
I had a problem with this line. I don't use jQuery in my projects. And to fix the dependency on jQuery, we can replace `$.each` to `forEach` function. It works correctly for me.

@xSirrioNx Please, merge it as soon as possible and release a new version with the fix. I want to use your repo in my package.json.