### PR TITLE
Add support for frozen pane

### DIFF
--- a/README.md
+++ b/README.md
@@ -808,6 +808,16 @@ In addition to the base sheet keys, worksheets also add:
   the worksheet.  Plaintext utilities are unaware of merge cells.  CSV export
   will write all cells in the merge range if they exist, so be sure that only
   the first cell (upper-left) in the range is set.
+  
+- `ws['!viewPane']`: object representing Worksheet View pane
+  
+  | Property Name | Default   | Description |
+  | :------------ | --------: | :---------- |
+  | state         | 'split'   | Type of pane: 'split' \|\| 'frozen' \|\| 'frozenSplit' |
+  | xSplit        | 0         | For 'split', horizontal position of the splitter, in 1/20th of a point. For 'frozen' and 'frozenSplit', amount of frozen columns. |
+  | ySplit        | 0         | For 'split', vertical position of the splitter, in 1/20th of a point. For 'frozen' and 'frozenSplit', amount of frozen rows. |
+  | topLeftCell   | special   | The cell to be top-left in the bottom-right pane. For 'frozen' and 'frozenSplit', defaults to the cell in first unfrozen column and first unfrozen row |
+  | activePane    | undefined | 'topLeft' \|\| 'topRight' \|\| 'bottomLeft' \|\| 'bottomRight' \|\| |
 
 - `ws['!protect']`: object of write sheet protection properties.  The `password`
   key specifies the password for formats that support password-protected sheets

--- a/bits/67_wsxml.js
+++ b/bits/67_wsxml.js
@@ -182,7 +182,9 @@ function write_ws_xml_autofilter(data)/*:string*/ {
 /* 18.3.1.88 sheetViews CT_SheetViews */
 /* 18.3.1.87 sheetView CT_SheetView */
 function write_ws_xml_sheetviews(ws, opts, idx, wb)/*:string*/ {
-	return writextag("sheetViews", writextag("sheetView", null, {workbookViewId:"0"}), {});
+    var sheetViewPane = ws['!viewPane'] !== undefined ? write_ws_xml_view_pane(ws['!viewPane']) : null;
+
+	return writextag("sheetViews", writextag("sheetView", sheetViewPane, {workbookViewId:"0"}), {});
 }
 
 function write_ws_xml_cell(cell, ref, ws, opts, idx, wb) {
@@ -510,4 +512,24 @@ function write_ws_xml(idx/*:number*/, opts, wb/*:Workbook*/, rels)/*:string*/ {
 
 	if(o.length>2) { o[o.length] = ('</worksheet>'); o[1]=o[1].replace("/>",">"); }
 	return o.join("");
+}
+
+function write_ws_xml_view_pane(pane) {
+  var p = {
+    state: pane.state === 'split' || pane.state === 'frozen' || pane.state === 'frozenSplit' ? pane.state : 'split',
+    xSplit: pane.xSplit || 0,
+    ySplit: pane.ySplit || 0
+  };
+
+  // If frozen pane, defaults to the cell in first unfrozen column and first unfrozen row
+  if (p.state !== 'split') {
+    p.topLeftCell = pane.topLeftCell || encode_cell({c: p.xSplit, r: p.ySplit});
+  }
+  else if (pane.topLeftCell !== undefined) {
+    p.topLeftCell = pane.topLeftCell;
+  }
+
+  if (pane.activePane !== undefined) p.activePane = pane.activePane;
+
+  return writextag('pane', null, p);
 }


### PR DESCRIPTION
Integration the following PR to this repo: https://github.com/protobi/js-xlsx/pull/50

I tested it. It works correctly for me (Excel 2010, Excel 2016). For the Numbers app on OS X, this option was ignored (it's normal, the Numbers app doesn't have support for frozen pane).

You can test it using the manual about `!viewPane` option in the `README.md` file.